### PR TITLE
Renamed NQDC to pubget

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,18 @@ Please check our [Guidelines for Contributors](https://github.com/neurocausal/ne
 
 ### Dependencies
 
-The development of the NeuroCausal meta-analysis pipeline will be built on [NeuroQuery](https://github.com/neuroquery/neuroquery) metaanalysis and [NeuroQuery Data Collection](https://github.com/neuroquery/nqdc) packages. 
+The development of the NeuroCausal meta-analysis pipeline will be built on [NeuroQuery](https://github.com/neuroquery/neuroquery) metaanalysis and [pubget](https://github.com/neuroquery/pubget) packages. 
 
 ### Installation
 We would like you to install both NeuroQuery packages by following the commands below:
 
-To install the main repo version of the NQDC, type
+To install the main repo version of the `pubget`, type
 
-`pip install git+https://github.com/neuroquery/nqdc.git`
+`pip install git+https://github.com/neuroquery/pubget.git`
 
 To install the NeuroQuery type 
 
-`pip install neuroquery`
+`pip install pubget`
 
 The packages will install additional packages listed in their requirement lists they list in their repository what NeuroCausal will be also sticking with. 
 

--- a/filter_clinical.py
+++ b/filter_clinical.py
@@ -164,7 +164,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--text_csv", "-t", type=str, required=True,
                         help="Path to the text.csv file containing the text "
-                             "of the paper from the nqdc extraction.")
+                             "of the paper from the pubget extraction.")
     parser.add_argument("--out_clinical_path", "-oc", type=str,
                         help="Output path for the csv file containing the "
                              "pmcid and whether the paper is clinical.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 conda
-nqdc
+pubget
 neuroquery
 nilearn
 sklearn


### PR DESCRIPTION
NQDC has been renamed pubget recently, so I changed the naming throughout neurocausal_meta (the nqdc repo is now only a README)